### PR TITLE
[BUGFIX] JS entrypoint name fixed

### DIFF
--- a/Classes/EventListener/PostProcessComponentViewEventListener.php
+++ b/Classes/EventListener/PostProcessComponentViewEventListener.php
@@ -26,10 +26,10 @@ class PostProcessComponentViewEventListener
         $cacheFactory = GeneralUtility::makeInstance(CacheFactory::class);
         $entryPointLookup = GeneralUtility::makeInstance(EntrypointLookup::class, $configuration['path'] ?? '', '_styleguide', true, $jsonDecoder, $io, $cacheFactory);
 
-        foreach ($entryPointLookup->getCssFiles($configuration['entryName'] ?? '') as $css) {
+        foreach ($entryPointLookup->getCssFiles($configuration['entryName'] ?? 'app') as $css) {
             $event->addHeaderData(' <link rel="stylesheet" href="' . htmlspecialchars($css) . '" />');
         }
-        foreach ($entryPointLookup->getJavaScriptFiles('app') as $js) {
+        foreach ($entryPointLookup->getJavaScriptFiles($configuration['entryName'] ?? 'app') as $js) {
             $event->addHeaderData('<script src="' . htmlspecialchars($js) . '"></script>');
         }
     }


### PR DESCRIPTION
When enter an entrypoint other then app, the extension will throw an exception, because it  can't find app.js. It seems it was forgotten to implement the entrypoint name for the js.

Additionally i added the same app behaviour for the css.